### PR TITLE
Bump clara-rules version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[com.google.guava/guava "15.0"] ; Explicitly pull new Guava version for dependency conflicts.
                  [org.clojure/clojure "1.7.0"]
-                 [org.toomuchcode/clara-rules "0.9.0"]
+                 [org.toomuchcode/clara-rules "0.9.2"]
                  [org.toomuchcode/clara-tools "0.1.1"]
 
                  ;; Dependencies for ClojureScript example.


### PR DESCRIPTION
I just noticed that clara-examples isn't using the most recent release of clara-rules; I'm guessing this was an oversight.
