### PR TITLE
Issue 9: Add example that demonstrates truth maintenance

### DIFF
--- a/src/main/clojure/clara/examples.clj
+++ b/src/main/clojure/clara/examples.clj
@@ -5,6 +5,7 @@
            [clara.examples.java.shopping :as jshopping]
            [clara.examples.booleans :as booleans]
            [clara.examples.fact-type-options :as type-opts]
+           [clara.examples.truth-maintenance :as truth]
            [clara.rules :as r]))
 
 (defn -main []
@@ -29,4 +30,7 @@
   (booleans/run-examples)
   (println)
   (println "Fact type options examples:")
-  (type-opts/run-examples))
+  (type-opts/run-examples)
+  (println)
+  (println "Truth maintenance examples: ")
+  (truth/run-examples))

--- a/src/main/clojure/clara/examples/truth_maintenance.clj
+++ b/src/main/clojure/clara/examples/truth_maintenance.clj
@@ -1,0 +1,86 @@
+(ns clara.examples.truth-maintenance
+  (:require [clara.rules.accumulators :as acc]
+            [clara.rules :refer :all]))
+
+(defrecord Temperature [temperature location])
+
+(defrecord LocalTemperatureRecords [high low location])
+
+(defrecord Cold [temperature])
+
+(defrecord AlwaysOverZeroLocation [location])
+
+(defrule insert-temperature-records
+  [?min-temp <- (acc/min :temperature) :from [Temperature (= ?loc location)]]
+  [?max-temp <- (acc/max :temperature) :from [Temperature (= ?loc location)]]
+  =>
+  (insert! (map->LocalTemperatureRecords {:high ?max-temp :low ?min-temp :location ?loc})))
+
+;; When a Temperature fact is inserted or retracted, the output of insert-temperature-records will
+;; be adjusted to compensate, and the output of this rule will in turn be adjusted to compensate for the
+;; change in the LocalTemperatureRecords facts in the session.
+(defrule always-over-zero
+  [LocalTemperatureRecords (> low 0) (= ?loc location)]
+  =>
+  (insert! (->AlwaysOverZeroLocation ?loc)))
+
+(defrule insert-cold-temperature
+  [Temperature (= ?temperature temperature) (< temperature 30)]
+  =>
+  (insert! (->Cold ?temperature)))
+
+(defquery cold-facts
+  "Query for Cold facts"
+  []
+  [Cold (= ?temperature temperature)])
+
+(defquery records-facts
+  "Query for LocalTemperatureRecord facts"
+  []
+  [LocalTemperatureRecords (= ?high high) (= ?low low) (= ?loc location)])
+
+(defquery always-over-zero-facts
+  "Query for AlwaysOverZeroLocation facts"
+  []
+  [AlwaysOverZeroLocation (= ?loc location)])
+
+(defn run-examples []
+  (let [initial-session (-> (mk-session 'clara.examples.truth-maintenance)
+                            (insert (->Temperature -10 "MCI")
+                                    (->Temperature 110 "MCI")
+                                    (->Temperature 20 "LHR")
+                                    (->Temperature 90 "LHR"))
+                            fire-rules)]
+
+    (println "Initial cold temperatures: "
+             (query initial-session cold-facts))
+    (println "Initial local temperature records: "
+             (query initial-session records-facts))
+    (println "Initial locations that have never been below 0: "
+             (query initial-session always-over-zero-facts))
+    (println "")
+    (println "Now add a temperature of -5 to LHR and a temperature of 115 to MCI")
+
+    (let [with-mods-session (-> initial-session
+                                (insert (->Temperature -5 "LHR")
+                                        (->Temperature 115 "MCI"))
+                                fire-rules)]
+      (println "New cold temperatures: "
+               (query with-mods-session cold-facts))
+      (println "New local temperature records: "
+               (query with-mods-session records-facts))
+      (println "New locations that have never been below 0: "
+               (query with-mods-session always-over-zero-facts))
+
+      (let [with-retracted-session (-> with-mods-session
+                                       (retract (->Temperature -5 "LHR"))
+                                       fire-rules)]
+
+        (println "")
+        (println "Now we retract the temperature of -5 at LHR")
+        (println "Cold temperatures with this retraction: "
+                 (query with-retracted-session cold-facts))
+        (println "Local temperature records with this retraction: "
+                 (query with-retracted-session records-facts))
+        (println "Locations that have never been below zero with this retraction: "
+                 (query with-retracted-session always-over-zero-facts))))))


### PR DESCRIPTION
Output of "lein run -m clara.examples" with this branch:

````
Shopping examples:
VIP shopping example:
10 % :vip discount???
Summer special and widget promotion example:
20 % :summer-special discount???
Free :lunch for promotion :free-lunch-with-gizmo
Free :widget for promotion :free-widget-month

JavaBean Shopping examples from Clojure:
Promotion: Awesome promotion for our favorite VIP!

JavaBean Shopping examples from Java:
Query result: DESCRIPTION: Awesome promotion for our favorite VIP!

Validation examples:
Failed validation:
Validation issue:  HVAC repairs must include a 27B-6 form.
Validation issue:  Insufficient time prior to due date of the large order.
Validation with appropriate client tier and paperwork.

Sensor examples:
Reducing speed of  #clara.examples.sensors.Device{:id 456, :location :room-1}
Reducing speed of  #clara.examples.sensors.Device{:id 123, :location :room-1}
ALERT: temperature of 130 at :room-1 in sector :sector-5
Increasing speed of  #clara.examples.sensors.Device{:id 123, :location :room-1}
Increasing speed of  #clara.examples.sensors.Device{:id 456, :location :room-1}

Discounts when a customer is both a NewCustomer and a ValuedCustomer:  ({:?order-id 1, :?amount 20} {:?order-id 1, :?amount 5} {:?order-id 1, :?amount 5})
Discounts when the customer is noted as new twice in the session:  ({:?order-id 1, :?amount 5} {:?order-id 1, :?amount 5})
Discounts when there is a CustomerAppreciationDay, but it does not match the CurrentDay:  ()
Discounts when an Order matches both branches of clojure.core/or :  ({:?order-id 3, :?amount 10})

Boolean expression examples:
Discounts when a customer is both a NewCustomer and a ValuedCustomer:  ({:?order-id 1, :?amount 20} {:?order-id 1, :?amount 5} {:?order-id 1, :?amount 5})
Discounts when the customer is noted as new twice in the session:  ({:?order-id 1, :?amount 5} {:?order-id 1, :?amount 5})
Discounts when there is a CustomerAppreciationDay, but it does not match the CurrentDay:  ()
Discounts when an Order matches both branches of clojure.core/or :  ({:?order-id 3, :?amount 10})

Fact type options examples:
Query result with a fact of type :temperature-reading :  ({:?good-weather false})
Query result with a custom ancestors function and a fact with a type that descends from :temperature-reading :  ({:?good-weather false})

Truth maintenance examples: 
Initial cold temperatures:  ({:?temperature -10} {:?temperature 20})
Initial local temperature records:  ({:?high 110, :?low -10, :?loc MCI} {:?high 90, :?low 20, :?loc LHR})
Initial locations that have never been below 0:  ({:?loc LHR})

Now add a temperature of -5 to LHR and a temperature of 115 to MCI
New cold temperatures:  ({:?temperature -10} {:?temperature 20} {:?temperature -5})
New local temperature records:  ({:?high 90, :?low -5, :?loc LHR} {:?high 115, :?low -10, :?loc MCI})
New locations that have never been below 0:  ()

Now we retract the temperature of -5 at LHR
Cold temperatures with this retraction:  ({:?temperature -10} {:?temperature 20})
Local temperature records with this retraction:  ({:?high 90, :?low 20, :?loc LHR} {:?high 115, :?low -10, :?loc MCI})
Locations that have never been below zero with this retraction:  ({:?loc LHR})
````